### PR TITLE
Changes to swap rule and to acc_tuner

### DIFF
--- a/src/mopt/AlgoBGP.jl
+++ b/src/mopt/AlgoBGP.jl
@@ -369,7 +369,7 @@ mutable struct MAlgoBGP <: MAlgo
     anim           :: Plots.Animation
     dist_fun   :: Function
 
-    function MAlgoBGP(m::MProb,opts=Dict("N"=>3,"maxiter"=>100,"maxtemp"=> 2,"coverage"=>0.125,"sigma_update_steps"=>10,"sigma_adjust_by"=>0.01,"smpl_iters"=>1000,"parallel"=>false,"maxdists"=>[0.0 for i in 1:3],"acc_tuner"=>[2.0 for i in 1:3]))
+    function MAlgoBGP(m::MProb,opts=Dict("N"=>3,"maxiter"=>100,"maxtemp"=> 2,"coverage"=>0.125,"sigma_update_steps"=>10,"sigma_adjust_by"=>0.01,"smpl_iters"=>1000,"parallel"=>false,"maxdists"=>[0.0 for i in 1:3],"acc_tuners"=>[2.0 for i in 1:3]))
 
         init_sd = OrderedDict{Symbol,Float64}()
         if opts["N"] > 1

--- a/src/mopt/AlgoBGP.jl
+++ b/src/mopt/AlgoBGP.jl
@@ -369,7 +369,7 @@ mutable struct MAlgoBGP <: MAlgo
     anim           :: Plots.Animation
     dist_fun   :: Function
 
-    function MAlgoBGP(m::MProb,opts=Dict("N"=>3,"maxiter"=>100,"maxtemp"=> 2,"coverage"=>0.125,"sigma_update_steps"=>10,"sigma_adjust_by"=>0.01,"smpl_iters"=>1000,"parallel"=>false,"maxdists"=>[0.5 for i in 1:3],"acc_tuner"=>2.0))
+    function MAlgoBGP(m::MProb,opts=Dict("N"=>3,"maxiter"=>100,"maxtemp"=> 2,"coverage"=>0.125,"sigma_update_steps"=>10,"sigma_adjust_by"=>0.01,"smpl_iters"=>1000,"parallel"=>false,"maxdists"=>[0.0 for i in 1:3],"acc_tuner"=>[2.0 for i in 1:3]))
 
         init_sd = OrderedDict{Symbol,Float64}()
         if opts["N"] > 1
@@ -388,7 +388,7 @@ mutable struct MAlgoBGP <: MAlgo
                 # @assert init_sd[k] == b / quantile(Normal(),0.975)
                 init_sd[k] = b / quantile(Normal(),0.975)
             end
-            BGPChains = BGPChain[BGPChain(i,opts["maxiter"],m,collect(values(init_sd)) .* temps[i],get(opts,"sigma_update_steps",10),get(opts,"sigma_adjust_by",0.01),get(opts,"smpl_iters",1000),get(opts,"maxdists",[0.5 for j in 1:opts["N"]])[i],get(opts,"acc_tuner",2.0)) for i in 1:opts["N"]]
+            BGPChains = BGPChain[BGPChain(i,opts["maxiter"],m,collect(values(init_sd)) .* temps[i],get(opts,"sigma_update_steps",10),get(opts,"sigma_adjust_by",0.01),get(opts,"smpl_iters",1000),get(opts,"maxdists",[0.0 for j in 1:opts["N"]])[i],get(opts,"acc_tuners",[2.0 for j in 1:opts["N"]])[i]) for i in 1:opts["N"]]
           else
             temps     = [1.0]
             for (k,v) in m.params_to_sample
@@ -396,9 +396,9 @@ mutable struct MAlgoBGP <: MAlgo
                 init_sd[k] = b / quantile(Normal(),0.975)
             end
             # println(init_sd)
-            BGPChains = BGPChain[BGPChain(1,opts["maxiter"],m,collect(values(init_sd)) .* temps[1],get(opts,"sigma_update_steps",10),get(opts,"sigma_adjust_by",0.01),get(opts,"smpl_iters",1000),get(opts,"maxdists",[0.5 for j in 1:opts["N"]])[1],get(opts,"acc_tuner",2.0)) ]
+            BGPChains = BGPChain[BGPChain(1,opts["maxiter"],m,collect(values(init_sd)) .* temps[1],get(opts,"sigma_update_steps",10),get(opts,"sigma_adjust_by",0.01),get(opts,"smpl_iters",1000),get(opts,"maxdists",[0.0 for j in 1:opts["N"]])[1],get(opts,"acc_tuners",[2.0 for j in 1:opts["N"]])[1]) ]
         end
-	    return new(m,opts,0,BGPChains, Animation(),abs)
+	    return new(m,opts,0,BGPChains, Animation(),-)
     end
 end
 
@@ -536,8 +536,8 @@ function exchangeMoves!(algo::MAlgoBGP)
         # BGP version
         # exchange i with j if rho(S(z_j),S(data)) < epsilon_i
         @debug(logger,"Exchanging $i with $j? Distance is $(algo.dist_fun(evj.value - evi.value))")
-        @debug(logger,"Exchange: $(algo.dist_fun(evj.value - evi.value)  < algo["maxdists"][i])")
-        if algo.dist_fun(evj.value - evi.value)  < algo["maxdists"][i]
+        @debug(logger,"Exchange: $(algo.dist_fun(evj.value, evi.value)  < algo["maxdists"][i])")
+        if algo.dist_fun(evj.value, evi.value)  < algo["maxdists"][i]
             swap_ev_ij!(algo,i,j)
         end
     end

--- a/src/mopt/Examples.jl
+++ b/src/mopt/Examples.jl
@@ -32,7 +32,7 @@ function parallelNormal(niter=200)
 		"parallel"=>true,
 		"maxdists"=>[0.05 for i in 1:nchains],
 		"mixprob"=>0.3,
-		"acc_tuner"=>12.0,
+		"acc_tuners"=>[12.0 for i in 1:nchains],
 		"animate"=>false)
 
 	# plot slices of objective function
@@ -90,7 +90,7 @@ function serialNormal(niter=200)
 		"parallel"=>false,
 		"maxdists"=>[0.05 for i in 1:nchains],
 		"mixprob"=>0.3,
-		"acc_tuner"=>12.0,
+		"acc_tuners"=>[0.05 for i in 1:nchains],
 		"animate"=>false)
 
 	# plot slices of objective function
@@ -135,7 +135,7 @@ function BGP_example()
 		"coverage"=>0.005,  # i.e. this gives you a 95% CI about the current parameter on chain number 1.
 		"maxdists"=>linspace(0.025, 2,nchains),
 		"mixprob"=>0.3,
-		"acc_tuner"=>12.0,
+		"acc_tuners"=>[0.05 for i in 1:nchains],
 		"animate"=>false)
 	# setup the BGP algorithm
 	MA = MAlgoBGP(mprob,opts)


### PR DESCRIPTION
In order to implement the swap rule
```
if evj.value - evi.value < algo["maxdists"][i]
            swap_ev_ij!(algo,i,j)
end
```
I realized I could simply change the default `dist_fun` into `-`, so that the algorithm looks at `algo.dist_fun(evj.value, evi.value)` being by default `-(evj.value, evi.value)` but still being editable by users. In addition, I changed the default `maxdists` to a vector of zeros, so that the default swap rule is simply `evj.value < evi.value`, as suggested by BGP.

I also introduced a vector `acc_tuners` as a field of `MAlgoBGP` so that each chain can have its own value for `acc_tuner`. This allows for more control on the algorithm. Ideally, one might want to be more restrictive (i.e., higher `acc_tuner`) on colder chains.