### PR TITLE
standardize parameter space in proposal function

### DIFF
--- a/src/MomentOpt.jl
+++ b/src/MomentOpt.jl
@@ -45,6 +45,7 @@ export addParam!,
        dataMomentd,
        dataMomentW,
        summary,
+       params,
        param,
        paramd,
        doSlices,
@@ -54,7 +55,8 @@ export addParam!,
        readMalgo,
        restartMOpt!,
        extendBGPChain!,
-       runMOpt!
+       runMOpt!,
+       mean,median,CI
 
 # create a random device that is immune to seeds
 const RAND = RandomDevice()

--- a/src/mopt/Examples.jl
+++ b/src/mopt/Examples.jl
@@ -121,7 +121,7 @@ function snorm_standard()
 	pb = OrderedDict()
 	pb["p1"] = [0.2,-3,3]
 	pb["p2"] = [-0.2,-2,2]
-	moms = DataFrame(name=["mu1","mu2"],value=[-1.0,1.0],weight=[-1.0,1.0])
+	moms = DataFrame(name=["mu1","mu2"],value=[-1.0,1.0],weight=[1.0,1.0])
 
 	nchains = 3
 
@@ -172,7 +172,7 @@ function snorm_6_taxi(tol;par=false)
 	pb["p5"] = [0.3,-2,2]
 	pb["p6"] = [0.4,-2,2]
 	moms = DataFrame(name=["mu1","mu2","mu3","mu4","mu5","mu6"],
-		value=[-1.0,1.0,0.5,-0.5,0.7,-0.7],weight=[-1.0,1.0,0.5,-0.5,0.7,-0.7])
+		value=[-1.0,1.0,0.5,-0.5,0.7,-0.7],weight=ones(6))
 	
 	mprob = MProb() 
 	addSampledParam!(mprob,pb) 
@@ -232,7 +232,7 @@ function snorm_18(niter)
 						   "mu16",
 						   "mu17",
 						   "mu18"],
-		value=[-1.0,0.0,0.5,-0.5,0.008,-0.7,-1.0,0.0,0.5,-0.5,0.008,-0.7,-1.0,0.0,0.5,-0.5,0.008,-0.7],weight=[-1.0,0.0,0.5,-0.5,0.008,-0.7,-1.0,0.0,0.5,-0.5,0.008,-0.7,-1.0,0.0,0.5,-0.5,0.008,-0.7])
+		value=[-1.0,0.0,0.5,-0.5,0.008,-0.7,-1.0,0.0,0.5,-0.5,0.008,-0.7,-1.0,0.0,0.5,-0.5,0.008,-0.7],weight=[1.0,0.1,0.5,0.5,0.008,0.7,1.0,0.1,0.5,0.5,0.008,0.7,1.0,0.1,0.5,0.5,0.008,0.7])
 
 	nchains = 3
 
@@ -244,6 +244,7 @@ function snorm_18(niter)
             # where b = (p[:ub]-p[:lb])*opts["coverage"] i.e. the fraction of the search interval you want to search around the initial value
 		"coverage"=>0.02,   # how big should the step size of new params be?
 		"smpl_iters"=>1000,
+		"sigma"=>0.001,
 		"parallel"=>false,
 		"maxdists"=>[0.0 for i in 1:nchains],
 		"acc_tuners"=>[20;2;1.0],
@@ -291,7 +292,7 @@ function snorm_standard6()
 	pb["p5"] = [0.3,-2,2]
 	pb["p6"] = [0.4,-2,2]
 	moms = DataFrame(name=["mu1","mu2","mu3","mu4","mu5","mu6"],
-		value=[-1.0,1.0,0.5,-0.5,0.7,-0.7],weight=[-1.0,1.0,0.5,-0.5,0.7,-0.7])
+		value=[-1.0,1.0,0.5,-0.5,0.7,-0.7],weight=[1.0,1.0,0.5,0.5,0.7,0.7])
 
 	nchains = 3
 

--- a/src/mopt/Examples.jl
+++ b/src/mopt/Examples.jl
@@ -42,7 +42,7 @@ function parallelNormal(niter=200)
 		"sigma_adjust_by"=>0.01,
 		"smpl_iters"=>1000,
 		"parallel"=>true,
-		"maxdists"=>[0.05 for i in 1:nchains],
+		"min_improve"=>[0.05 for i in 1:nchains],
 		"mixprob"=>0.3,
 		"acc_tuners"=>[12.0 for i in 1:nchains],
 		"animate"=>false)
@@ -84,7 +84,7 @@ function serialNormal(npars,niter;save=false)
 			"coverage"=>0.02,   # how big should the step size of new params be?
 			"smpl_iters"=>1000,
 			"parallel"=>false,
-			"maxdists"=>[0.0 for i in 1:nchains],
+			"min_improve"=>[0.0 for i in 1:nchains],
 			"acc_tuners"=>[20;2;1.0],
 			"animate"=>false)
 	else
@@ -97,7 +97,7 @@ function serialNormal(npars,niter;save=false)
 		"coverage"=>0.05,   # how big should the step size of new params be?
 		"smpl_iters"=>1000,
 		"parallel"=>false,
-		"maxdists"=>[0.0 for i in 1:nchains],
+		"min_improve"=>[0.0 for i in 1:nchains],
 		"acc_tuners"=>[50.0;10;5],
 		"animate"=>false)
 
@@ -134,7 +134,7 @@ function snorm_standard()
 		"coverage"=>0.02,   # how big should the step size of new params be?
 		"smpl_iters"=>1000,
 		"parallel"=>false,
-		"maxdists"=>[0.0 for i in 1:nchains],
+		"min_improve"=>[0.0 for i in 1:nchains],
 		"acc_tuners"=>[20;2;1.0],
 		"animate"=>false)
 	info("These moments are our targets")
@@ -246,7 +246,7 @@ function snorm_18(niter)
 		"smpl_iters"=>1000,
 		"sigma"=>0.001,
 		"parallel"=>false,
-		"maxdists"=>[0.0 for i in 1:nchains],
+		"min_improve"=>[0.0 for i in 1:nchains],
 		"acc_tuners"=>[20;2;1.0],
 		"animate"=>false,
 		"batch_size" => 1)
@@ -305,7 +305,7 @@ function snorm_standard6()
 		"coverage"=>0.02,   # how big should the step size of new params be?
 		"smpl_iters"=>1000,
 		"parallel"=>false,
-		"maxdists"=>[0.0 for i in 1:nchains],
+		"min_improve"=>[0.0 for i in 1:nchains],
 		"acc_tuners"=>[20;2;1.0],
 		"animate"=>false)
 	info("These moments are our targets")
@@ -417,7 +417,7 @@ function BGP_example()
             # such that Pr( x \in [init-b,init+b]) = 0.975
             # where b = (p[:ub]-p[:lb])*opts["coverage"] i.e. the fraction of the search interval you want to search around the initial value
 		"coverage"=>0.005,  # i.e. this gives you a 95% CI about the current parameter on chain number 1.
-		"maxdists"=>linspace(0.025, 2,nchains),
+		"min_improve"=>linspace(0.025, 2,nchains),
 		"mixprob"=>0.3,
 		"acc_tuners"=>[12.0 for i in 1:nchains],
 		"animate"=>false)

--- a/src/mopt/ObjExamples.jl
+++ b/src/mopt/ObjExamples.jl
@@ -87,11 +87,11 @@ function objfunc_norm(ev::Eval)
 		i += 1
 		simMoments[k] = simM[i]
 		if haskey(dataMomentWd(ev),k)
-			# v[k] = ((simMoments[k] .- mom) ./ dataMomentW(ev,k)) .^2
-			v[k] = (simMoments[k] ./ mom .- 1.0) .^2    # true scale of all moments is 1.0
+			v[k] = ((simMoments[k] .- mom) ./ dataMomentW(ev,k)) .^2
+			# v[k] = (simMoments[k] ./ mom .- 1.0) .^2    # true scale of all moments is 1.0
 		else
-			# v[k] = ((simMoments[k] .- mom) ) .^2
-			v[k] = (simMoments[k] ./ mom .- 1.0) .^2
+			v[k] = ((simMoments[k] .- mom) ) .^2
+			# v[k] = (simMoments[k] ./ mom .- 1.0) .^2
 		end
 	end
 	setValue(ev, mean(collect(values(v))))

--- a/src/mopt/mprob.jl
+++ b/src/mopt/mprob.jl
@@ -138,7 +138,11 @@ function addEvalFunc!(m::MProb,f::Function)
   m.objfunc = f
 end
 
-# evalute objective function
+"""
+    evaluateObjective(m::MProb,p::Union{Dict,OrderedDict})
+
+Evaluate the objective function of an [`MProb`](@ref) at a given parameter vector `p`.
+"""
 function evaluateObjective(m::MProb,p::Union{Dict,OrderedDict})
     ev = Eval(m,p)
     try
@@ -152,6 +156,11 @@ function evaluateObjective(m::MProb,p::Union{Dict,OrderedDict})
     return ev
 end
 
+"""
+    evaluateObjective(m::MProb,ev::Eval)
+
+Evaluate the objective function of an [`MProb`](@ref) at a given `Eval`.
+"""
 function evaluateObjective(m::MProb,ev)
     # catching errors
     try

--- a/src/mopt/mprob.jl
+++ b/src/mopt/mprob.jl
@@ -188,6 +188,21 @@ function ms_names(mprob::MProb)
   return(keys(mprob.moments))
 end
 
+"""
+    map param to [0,1]
+"""
+function mapto_01(p::OrderedDict,lb::Vector{Float64},ub::Vector{Float64})
+    mu = collect(values(p))
+    return (mu .- lb) ./ (ub .- lb)
+end
+
+"""
+    map param from [0,1] to [a,b]
+"""
+function mapto_ab(p::Vector{Float64},lb::Vector{Float64},ub::Vector{Float64})
+    p .* (ub .- lb) .+ lb
+end
+
 function show(io::IO,m::MProb)
 
   print(io,"MProb Object:\n")

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 TestSetExtensions
 DataFrames
+JSON

--- a/test/include/test-include.jl
+++ b/test/include/test-include.jl
@@ -8,8 +8,8 @@ function test_chain()
     addEvalFunc!(mprob,MomentOpt.objfunc_norm)
     id = 180
     n = 23
-    sig = rand(length(pb))
-    sig2 = rand(length(pb))
+    sig = rand()
+    sig2 = rand()
     upd = 5
     upd_by = rand()
     ite = 1000
@@ -27,8 +27,8 @@ function test_chain2()
     addEvalFunc!(mprob,MomentOpt.objfunc_norm)
     id = 180
     n = 23
-    sig = rand(length(pb))
-    sig2 = rand(length(pb))
+    sig = rand()
+    sig2 = rand()
     upd = 5
     upd_by = rand()
     ite = 1000
@@ -82,8 +82,8 @@ function test_chain3()
     addEvalFunc!(mprob,MomentOpt.objfunc_norm)
     id = 180
     n = 100
-    sig = rand(length(pb))
-    sig2 = rand(length(pb))
+    sig = rand()
+    sig2 = rand()
     upd = 5
     upd_by = rand()
     ite = 1000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Base.Test
 using TestSetExtensions
 using DataFrames
 using DataStructures
+using JSON
 
 # If we want the test to pass, we need this
 # see https://github.com/JuliaPlots/Plots.jl/issues/1076

--- a/test/test_AlgoAbstract.jl
+++ b/test/test_AlgoAbstract.jl
@@ -25,7 +25,7 @@
             "sigma_adjust_by"=>0.01,
             "smpl_iters"=>1000,
             "parallel"=>true,
-            "maxdists"=>[0.05 for i in 1:nchains],
+            "min_improve"=>[0.05 for i in 1:nchains],
             "mixprob"=>0.3,
             "acc_tuner"=>12.0,
             "animate"=>false,

--- a/test/test_BGPchain.jl
+++ b/test/test_BGPchain.jl
@@ -15,7 +15,7 @@
 		@test chain.accepted == falses(n)
 		@test chain.exchanged == zeros(Int,n)
 		for (six,ix) in enumerate(chain.batches)
-			@test diag(chain.sigma[six]) == sig[ix]
+			@test chain.sigma == sig
 		end
 		@test chain.sigma_update_steps == upd
 		@test chain.sigma_adjust_by == upd_by

--- a/test/test_algoBGP.jl
+++ b/test/test_algoBGP.jl
@@ -85,33 +85,36 @@
 		        "maxiter"=>niter,
 		        "maxtemp"=> 5,
 		        "coverage"=>0.025,
-		        "sigma_update_steps"=>10,
+		        "sigma_update_steps"=>niter+1,  # never adjust variances
 		        "sigma_adjust_by"=>0.01,
 		        "smpl_iters"=>1000,
 		        "parallel"=>true,
-		        "maxdists"=>[0.0 for i in 1:nchains],
+		        "min_improve"=>[0.0 for i in 1:nchains],
 		        "acc_tuners"=>[5;1.0],
 		        "animate"=>false)
 		MA = MAlgoBGP(mprob,opts)
 		MomentOpt.runMOpt!(MA)
 
-		dat_chain1 = MomentOpt.history(MA.chains[1])
-		dat_chain1[round(Int, niter/10):niter, :]
-		dat_chain1 = dat_chain1[dat_chain1[:accepted ].== true, : ]
+		me = mean(MA.chains[1])
+		med = median(MA.chains[1])
+		ci = CI(MA.chains[1])
+		
+		println("truth = ")
+		print(json(trueValues,4))
+		println()
+		println("means after $niter iterations = ")
+		print(json(me,4))
+		println()
+		println("medians after $niter iterations = ")
+		print(json(med,4))
+		println()
+		println("95% CI = ")
+		print(json(ci,4))
+		println()
 
-		parameters = [Symbol(String("mu$(i)")) for i=1:2]
-		estimatedParameters = [Symbol(String("p$(i)")) for i=1:2]
-
-		for (estimatedParameter, param) in zip(estimatedParameters, parameters)
-
-		  println("Quasi posterior mean for $(String(estimatedParameter)) = $(mean(dat_chain1[estimatedParameter]))")
-		  println("Quasi posterior median for $(String(estimatedParameter)) = $(median(dat_chain1[estimatedParameter]))")
-		  println("True value = $(trueValues[String(param)][])")
-
-			# (the problem is simple here)
-			#---------------------------------------------------------
-			@test trueValues[String(param)][] ≈ median(dat_chain1[estimatedParameter]) atol = tolTestNormal
-
+		for i in 1:2
+			ix = ("mu$i","p$i")
+			@test trueValues[ix[1]][1] ≈ med[Symbol(ix[2])] atol = tolTestNormal
 		end
 
 	    rmprocs(workers())
@@ -148,11 +151,11 @@
 		        "maxiter"=>niter,
 		        "maxtemp"=> 5,
 		        "coverage"=>0.025,
-		        "sigma_update_steps"=>10,
+		        "sigma_update_steps"=>10,  # adjust variances each 10 steps
 		        "sigma_adjust_by"=>0.01,
 		        "smpl_iters"=>1000,
 		        "parallel"=>true,
-		        "maxdists"=>[0.05 for i in 1:nchains],
+		        "min_improve"=>[0.05 for i in 1:nchains],
 		        "mixprob"=>0.3,
 		        "acc_tuner"=>12.0,
 		        "animate"=>false,
@@ -160,23 +163,30 @@
 		MA = MAlgoBGP(mprob,opts)
 		MomentOpt.runMOpt!(MA)
 
-		dat_chain1 = MomentOpt.history(MA.chains[1])
-		dat_chain1[round(Int, niter/10):niter, :]
-		dat_chain1 = dat_chain1[dat_chain1[:accepted ].== true, : ]
+		# dat_chain1 = MomentOpt.history(MA.chains[1])
+		# dat_chain1[round(Int, niter/10):niter, :]
+		# dat_chain1 = dat_chain1[dat_chain1[:accepted ].== true, : ]
 
-		parameters = [Symbol(String("mu$(i)")) for i=1:2]
-		estimatedParameters = [Symbol(String("p$(i)")) for i=1:2]
+		me = mean(MA.chains[1])
+		med = median(MA.chains[1])
+		ci = CI(MA.chains[1])
 
-		for (estimatedParameter, param) in zip(estimatedParameters, parameters)
+		println("truth = ")
+		print(json(trueValues,4))
+		println()
+		println("means after $niter iterations = ")
+		print(json(me,4))
+		println()
+		println("medians after $niter iterations = ")
+		print(json(med,4))
+		println()
+		println("95% CI = ")
+		print(json(ci,4))
+		println()
 
-		  println("Quasi posterior mean for $(String(estimatedParameter)) = $(mean(dat_chain1[estimatedParameter]))")
-		  println("Quasi posterior median for $(String(estimatedParameter)) = $(median(dat_chain1[estimatedParameter]))")
-		  println("True value = $(trueValues[String(param)][])")
-
-			# (the problem is simple here)
-			#---------------------------------------------------------
-			@test trueValues[String(param)][] ≈ median(dat_chain1[estimatedParameter]) atol = tolTestNormal
-
+		for i in 1:2
+			ix = ("mu$i","p$i")
+			@test trueValues[ix[1]][1] ≈ med[Symbol(ix[2])] atol = tolTestNormal
 		end
 
 	    rmprocs(workers())
@@ -210,7 +220,7 @@
 		        "sigma_adjust_by"=>0.01,
 		        "smpl_iters"=>1000,
 		        "parallel"=>true,
-		        "maxdists"=>[0.05 for i in 1:nchains],
+		        "min_improve"=>[0.05 for i in 1:nchains],
 		        "mixprob"=>0.3,
 		        "acc_tuner"=>12.0,
 		        "animate"=>false)
@@ -243,7 +253,7 @@
 		        "sigma_adjust_by"=>0.01,
 		        "smpl_iters"=>1000,
 		        "parallel"=>true,
-		        "maxdists"=>[0.05 for i in 1:nchains],
+		        "min_improve"=>[0.05 for i in 1:nchains],
 		        "mixprob"=>0.3,
 		        "acc_tuner"=>12.0,
 		        "animate"=>false)

--- a/test/test_algoBGP.jl
+++ b/test/test_algoBGP.jl
@@ -141,7 +141,7 @@
 
 		# estimation options:
 		#--------------------
-		niter = 50
+		niter = 200
 		nchains = 2
 
 		opts = Dict("N"=>nchains,
@@ -199,7 +199,7 @@
 
 		addEvalFunc!(mprob, objfunc_norm)
 
-		niter = 20
+		niter = 180
 		nchains = 2
 
 		opts = Dict("N"=>nchains,
@@ -300,6 +300,11 @@
 		@test Qmedian[1,1] .== Qmedian[1,2]
 		@test Qmedian[2,1] .== Qmedian[2,2]
 
+	end
+
+	@testset "high-dim test" begin
+	    
+	    m = MomentOpt.snorm_18(100)
 	end
 
 


### PR DESCRIPTION
* i had issues when params are from widely different param scales
* the obvious solutions was to map all params in to one space
* also simplifies chain setup: now only one variance per chain.